### PR TITLE
Check presence of PSU_FAN before reading file with speed

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -68,6 +68,10 @@ class MlnxFan(FanBase):
             int: percentage of the max fan speed
         """
         speed = 0
+
+        if not self.get_presence():
+            return speed
+
         speed_in_rpm = utils.read_int_from_file(self.fan_speed_get_path)
 
         max_speed_in_rpm = utils.read_int_from_file(self.fan_max_speed_path)

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -79,6 +79,8 @@ class TestFan:
             fan.fan_speed_set_path: 153
         }
 
+        fan.get_presence = MagicMock(return_value=True)
+
         def mock_read_int_from_file(file_path, default=0, raise_exception=False):
             return mock_sysfs_content[file_path]
 


### PR DESCRIPTION
- Why I did it Error message occured when trying to read PSU_FAN file with speed: ERR pmon#psud: Failed to read from file /var/run/hw-management/thermal/psu2_fan1_speed_get - FileNotFoundError(2, 'No such file or directory')

This can happen when the power cord is disconnected from the PSU_FAN, so some files may be absent

- How I did it Check if PSU_FAN is present before getting its speed

- How to verify it 1) Disconnect power cord from PSU and power supply from system 2) Wait few minutes and then connect power supply to system without power cord 3) Check logs for errors

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

