### PR TITLE
Check if PSU files exists when getting psu_voltage properties

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -258,41 +258,48 @@ class Psu(FixedPsu):
 
     @property
     def psu_voltage(self):
-        if not self._psu_voltage:
-            psu_voltage_out = os.path.join(PSU_PATH, "power/psu{}_volt_out2".format(self.index))
-            if os.path.exists(psu_voltage_out):
-                self._psu_voltage = psu_voltage_out
-            else:
-                psu_voltage_out = os.path.join(PSU_PATH, "power/psu{}_volt".format(self.index))
-                if os.path.exists(psu_voltage_out):
-                    self._psu_voltage = psu_voltage_out
+        psu_volt_out2 = os.path.join(PSU_PATH, "power/psu{}_volt_out2".format(self.index))
+        psu_volt = os.path.join(PSU_PATH, "power/psu{}_volt".format(self.index))
+
+        if os.path.exists(psu_volt_out2):
+            self._psu_voltage = psu_volt_out2
+        elif os.path.exists(psu_volt):
+            self._psu_voltage = psu_volt
+        else:
+            self._psu_voltage = None
 
         return self._psu_voltage
 
     @property
     def psu_voltage_min(self):
-        if not self._psu_voltage_min:
-            psu_voltage = self.psu_voltage
-            if psu_voltage:
-                self._psu_voltage_min = psu_voltage + "_min"
+        if self.psu_voltage:
+            psu_voltage_min_path = self.psu_voltage + "_min"
+            if os.path.exists(psu_voltage_min_path):
+                self._psu_voltage_min = psu_voltage_min_path
+            else:
+                self._psu_voltage_min = None
 
         return self._psu_voltage_min
 
     @property
     def psu_voltage_max(self):
-        if not self._psu_voltage_max:
-            psu_voltage = self.psu_voltage
-            if psu_voltage:
-                self._psu_voltage_max = psu_voltage + "_max"
+        if self.psu_voltage:
+            psu_voltage_max_path = self.psu_voltage + "_max"
+            if os.path.exists(psu_voltage_max_path):
+                self._psu_voltage_max = psu_voltage_max_path
+            else:
+                self._psu_voltage_max = None
 
         return self._psu_voltage_max
 
     @property
     def psu_voltage_capability(self):
-        if not self._psu_voltage_capability:
-            psu_voltage = self.psu_voltage
-            if psu_voltage:
-                self._psu_voltage_capability = psu_voltage + "_capability"
+        if self.psu_voltage:
+            psu_volt_cap_path = self.psu_voltage + "_capability"
+            if os.path.exists(psu_volt_cap_path):
+                self._psu_voltage_capability = psu_volt_cap_path
+            else:
+                self._psu_voltage_capability = None
 
         return self._psu_voltage_capability
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -105,6 +105,7 @@ class TestPsu:
         assert psu.get_maximum_supplied_power() is None
 
         mock_sysfs_content[psu.psu_oper_status] = 1
+        mock_sysfs_content[psu.psu_voltage_capability] = 1
         assert psu.get_voltage() == 10.234
         assert psu.get_voltage_high_threshold() == 12.0
         assert psu.get_voltage_low_threshold() == 9.0


### PR DESCRIPTION
- Why I did it Error messages occurred when trying to read PSU files on init: ERR pmon#psud: Failed to read from file /var/run/hw-management/power/psu1_volt_out2_capability - FileNotFoundError(2, 'No such file or directory')

This can happen when the power cord is disconnected from the PSU, so some PSU files may be absent, e.g.: /var/run/hw-management/power/psu2_volt_out2
/var/run/hw-management/power/psu2_volt_out2_capability

- How I did it Check if a file exists for a specific PSU parameter If not, return None so we can't read the PSU file any further

- How to verify it 1) Disconnect power cord from PSU and power supply from system 2) Wait few minutes and then connect power supply to system without power cord 3) Check logs for errors

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

